### PR TITLE
Fixed MilkMilkMilk button issue

### DIFF
--- a/src/components/milkMilkMilk.js
+++ b/src/components/milkMilkMilk.js
@@ -376,6 +376,7 @@ class milkMilkMilk extends React.Component {
             position: "absolute",
             top: "34%",
             right: 0,
+            zIndex: 1,
           }}
         >
           <Image

--- a/src/stylesheets/milkMilkMilkStyles.js
+++ b/src/stylesheets/milkMilkMilkStyles.js
@@ -111,6 +111,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     marginHorizontal: (screenWidth - 330) / 2,
     bottom: "5%",
+    zIndex: 3,
   },
   top: {
     backgroundColor: "#DD6755",


### PR DESCRIPTION
Changed the Z - Index of two elements on the page:
- The sprite_still.png index was set to 1, so it does not overlap with the QA box.
- The QA box index was set to 2, so it will always be in front of all of the other elements.
Things that need to still be fixed:
- Adjust the styling on some elements for android, later screens sprite seems to be a little lower than they are supposed to be on the figma